### PR TITLE
Fix upside-down translation map length

### DIFF
--- a/src/moderation/post_validation_cfg.py
+++ b/src/moderation/post_validation_cfg.py
@@ -71,7 +71,7 @@ def validate_post(text: str) -> Tuple[bool, Any]:
 
 _flip_map = str.maketrans(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-    "ɐqɔpǝɟƃɥᴉɾʞʅɯuodbɹsʇnʌʍxʎz∀qƆpƎℲפHΙſʞ⅂WNOԀΌᴚS⊥∩ΛMXʎZ⇂ᘔƐᘠട0"
+    "ɐqɔpǝɟƃɥᴉɾʞʅɯuodbɹsʇnʌʍxʎz∀qƆpƎℲפHΙſʞ⅂WNOԀΌᴚS⊥∩ΛMXʎZ⇂ᘔƐㄣϛ9ㄥ860"
 )
 
 def _render_inline(inline_parts) -> str:


### PR DESCRIPTION
## Summary
- ensure the upside-down translation map includes an entry for each alphanumeric character so `str.maketrans` receives matching lengths

## Testing
- `python - <<'PY'
import types, sys
textx = types.ModuleType("textx")
class DummyMM:
    def model_from_str(self, text):
        return text
textx.metamodel_from_str = lambda grammar: DummyMM()
class TextXSyntaxError(Exception):
    pass
textx.TextXSyntaxError = TextXSyntaxError
sys.modules['textx'] = textx
import importlib
m = importlib.import_module('src.moderation.post_validation_cfg')
print('Imported:', m.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e3210b8a8c832e94d5d4e6fffd8758