### PR TITLE
Update word token regex for alphanumeric content

### DIFF
--- a/src/moderation/post_validation_cfg.py
+++ b/src/moderation/post_validation_cfg.py
@@ -8,7 +8,7 @@ ignore: Space;
 HASHTAG: /#[A-Za-z0-9_]+/;
 MENTION: /@[A-Za-z0-9_]+/;
 LINK: /(https?:\/\/\S+)/;
-WORD: /[^@#\$\*\-_\/~\s][^@#\$\*\-_\/~]*/;
+WORD: /[A-Za-z0-9]+/;
 EMOJI: /[\U0001F300-\U0001FAFF]/;
 FORMULABODY: /[^$]+/;
 


### PR DESCRIPTION
## Summary
- adjust the WORD token in the moderation grammar to explicitly accept alphanumeric characters only, avoiding accidental ranges

## Testing
- pytest test/test_post_validation_cfg.py

------
https://chatgpt.com/codex/tasks/task_e_68e328d59508832e8fd57f35330520f3