### PR TITLE
Add unified moderation interface and supporting tests

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[1]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+_src_root = _repo_root / "src"
+if str(_src_root) not in sys.path:
+    sys.path.insert(0, str(_src_root))

--- a/src/interface.py
+++ b/src/interface.py
@@ -1,0 +1,84 @@
+"""Unified moderation interface for processing posts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from typing import Any, Dict
+
+from .moderation.content_classification_dfa import classify
+from .moderation.content_transformation_fst import transform
+from .moderation.post_validation_cfg import validate_post, render_preview
+
+
+def process_post(post: str) -> Dict[str, Any]:
+    """Run classification, transformation, and validation on ``post``.
+
+    Parameters
+    ----------
+    post:
+        Raw user supplied text.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Aggregated results containing the original post, classification flag,
+        transformation details, validation status, and rendered preview (when
+        available).
+    """
+
+    classification_report = classify(post)
+    classification_status = (
+        "Violation"
+        if any(
+            (
+                classification_report.hate,
+                classification_report.offensive,
+                classification_report.spam,
+            )
+        )
+        else "Safe"
+    )
+
+    transformation_result = transform(post)
+
+    is_valid, validation_obj = validate_post(post)
+    if is_valid:
+        preview = render_preview(validation_obj)
+        validation_payload = {"status": "Valid", "error": None}
+    else:
+        preview = None
+        validation_payload = {"status": "Invalid", "error": str(validation_obj)}
+
+    return {
+        "original_post": post,
+        "classification": {
+            "status": classification_status,
+            "details": asdict(classification_report),
+        },
+        "transformation": asdict(transformation_result),
+        "validation": validation_payload,
+        "preview": preview,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Moderation interface")
+    parser.add_argument(
+        "post",
+        nargs="?",
+        help="Post text to process. If omitted, the program prompts for input.",
+    )
+    args = parser.parse_args()
+
+    post = args.post
+    if post is None:
+        post = input("Enter the post to process: ")
+
+    result = process_post(post)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/moderation/content_classification_dfa.py
+++ b/src/moderation/content_classification_dfa.py
@@ -61,13 +61,14 @@ def preprocess(text: str):
 # 2) Map tokens into a small alphabet
 def categorize(token: str) -> str:
     # URLs and hashtags first 
-    if token.startswith("http") or token.startswith("www."):
+    lowered = token.lower()
+    if lowered.startswith("http") or lowered.startswith("www."):
         return "LINK"
-    if token.startswith("#"):
+    if lowered.startswith("#"):
         return "HASHTAG"
 
     # for example if gets: "idiot!" -> "idiot", "(stupid)" -> "stupid"
-    core = re.sub(r"^[^\w]+|[^\w]+$", "", token)
+    core = re.sub(r"^[^\w]+|[^\w]+$", "", lowered)
 
     if core in HATE_KEYWORDS:
         return "HATE"

--- a/src/moderation/content_transformation_fst.py
+++ b/src/moderation/content_transformation_fst.py
@@ -57,7 +57,7 @@ def transform(post: str) -> TransformResult:
     for tok, sym in zip(tokens, symbols):
         if sym in {"HATE", "OFFENSIVE"}:
             out.append("***")
-            masked.append(tok)
+            masked.append(tok.lower())
         else:
             out.append(tok)
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("textx")
+
+from src.interface import process_post
+
+
+def test_process_post_aggregates_outputs():
+    post = "Hello world"
+
+    result = process_post(post)
+
+    assert result["original_post"] == post
+    assert result["classification"]["status"] == "Safe"
+    classification_details = result["classification"]["details"]
+    assert classification_details["hate"] is False
+    assert classification_details["offensive"] is False
+    assert classification_details["spam"] is False
+
+    transformation = result["transformation"]
+    assert transformation["transformed_text"] == "hello world"
+    assert transformation["masked_tokens"] == []
+    assert transformation["suggestions"] == []
+
+    validation = result["validation"]
+    assert validation["status"] == "Valid"
+    assert validation["error"] is None
+
+    preview = result["preview"]
+    assert isinstance(preview, str)
+    assert "Hello" in preview


### PR DESCRIPTION
## Summary
- add a command-line interface that aggregates classification, transformation, validation, and preview data for posts
- normalize DFA categorization and transformation masking so offensive tokens are caught regardless of casing
- add pytest configuration and interface integration test to exercise the combined workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3333e792c832eb502302c11a058f7